### PR TITLE
Support scope-aware dynamic hotstrings

### DIFF
--- a/Hotstrings.json
+++ b/Hotstrings.json
@@ -1,0 +1,91 @@
+{
+  "version": 1,
+  "defaults": {
+    "options": "*",
+    "scopeMode": "include"
+  },
+  "scopes": {
+    "aliases": {
+      "Notepad": {
+        "process": ["notepad.exe"]
+      },
+      "SSMS": {
+        "process": ["ssms.exe", "ssms.app.exe"],
+        "titleRegex": "SQL Server Management Studio"
+      },
+      "AnyEditor": {
+        "process": ["notepad.exe", "notepad++.exe"],
+        "class": ["Notepad", "Notepad++"]
+      }
+    }
+  },
+  "hotstrings": [
+    {
+      "id": "sig",
+      "trigger": "sig",
+      "options": "*",
+      "text": "Best regards,{Enter}John",
+      "description": "Email signature",
+      "tags": ["email", "signature"],
+      "includeScopes": ["Notepad", "SSMS"],
+      "excludeScopes": [],
+      "enabled": true,
+      "priority": 100
+    },
+    {
+      "id": "addr",
+      "trigger": "addr",
+      "options": "",
+      "text": "123 Main St.",
+      "description": "Demo address",
+      "tags": ["address"],
+      "includeScopes": ["*"],
+      "excludeScopes": [],
+      "enabled": true
+    },
+    {
+      "id": "btw",
+      "trigger": "btw",
+      "options": "*",
+      "text": "by the way",
+      "description": "Common phrase",
+      "tags": ["text", "shortcut"],
+      "includeScopes": ["AnyEditor"],
+      "excludeScopes": [],
+      "enabled": true
+    },
+    {
+      "id": "ts_now",
+      "trigger": "now",
+      "options": "*",
+      "text": "%{DateTime:yyyy-MM-dd HH:mm}",
+      "description": "Current timestamp",
+      "tags": ["date", "time"],
+      "includeScopes": ["*"],
+      "excludeScopes": [],
+      "enabled": true
+    },
+    {
+      "id": "sql_use_db",
+      "trigger": "udb",
+      "options": "*",
+      "text": "USE [MyDatabase];{Enter}GO{Enter}",
+      "description": "SQL: switch database",
+      "tags": ["sql", "ssms"],
+      "includeScopes": ["SSMS"],
+      "excludeScopes": [],
+      "enabled": true
+    },
+    {
+      "id": "disabled_example",
+      "trigger": "demooff",
+      "options": "",
+      "text": "This one is off",
+      "description": "Disabled hotstring example",
+      "tags": ["demo"],
+      "includeScopes": ["*"],
+      "excludeScopes": [],
+      "enabled": false
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ You can customize the script's text expansions without touching the code. Define
 - A `defaults` section for shared options (e.g. default hotstring `options` or the fallback `scopeMode`).
 - Named scope aliases under `scopes.aliases`, where each alias can limit matches by process name, window class, or title regex.
 - A `hotstrings` array in which every entry specifies a `trigger` (or explicit `pattern`), optional `options`, output `text`, and scope rules via `includeScopes` / `excludeScopes`. Hotstrings can be toggled with `enabled`, prioritised through `priority`, and the output supports `%{DateTime:...}` placeholders that resolve to formatted timestamps during registration.
+
+Press **Win + Ctrl + Shift + H** to open a diagnostics window listing all dynamically registered hotstrings together with their send modes, scope summaries, and preview snippets. The dialog also exposes a shortcut to AutoHotkey's built-in **ListHotkeys** view so you can double-check which hotstrings the runtime currently recognises.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ Here are some screenshots showcasing the functionalities of MyWinToolbox:
 
 ### Note
 This project uses [AutoHotkey 2.0](https://www.autohotkey.com/). For detailed information about the language and its features, please refer to the [documentation](https://www.autohotkey.com/v2/).
+
+### Dynamic hotstrings
+You can customize the script's text expansions without touching the code. Define new hotstrings in **Hotstrings.json**. The file accepts a rich structure with:
+
+- A `defaults` section for shared options (e.g. default hotstring `options` or the fallback `scopeMode`).
+- Named scope aliases under `scopes.aliases`, where each alias can limit matches by process name, window class, or title regex.
+- A `hotstrings` array in which every entry specifies a `trigger` (or explicit `pattern`), optional `options`, output `text`, and scope rules via `includeScopes` / `excludeScopes`. Hotstrings can be toggled with `enabled`, prioritised through `priority`, and the output supports `%{DateTime:...}` placeholders that resolve to formatted timestamps during registration.


### PR DESCRIPTION
## Summary
- parse Hotstrings.json using defaults, scope aliases, and per-entry options with priority sorting
- register dynamic hotstrings with scope-aware predicates and DateTime placeholder expansion
- refresh the sample Hotstrings.json and README to document the new structure

## Testing
- not run (AutoHotkey runtime not available)


------
https://chatgpt.com/codex/tasks/task_e_68e56f9a9db483219e0bfb4868bcc8fc